### PR TITLE
Throw an error if no stream size information

### DIFF
--- a/build/write.js
+++ b/build/write.js
@@ -93,6 +93,9 @@ exports.write = function(device, stream) {
   var emitter, progress, size, _ref, _ref1;
   emitter = new EventEmitter();
   size = stream.length || ((_ref = stream.responseContent) != null ? (_ref1 = _ref.headers) != null ? _ref1['content-length'] : void 0 : void 0);
+  if (size == null) {
+    throw new Error('Stream size missing');
+  }
   progress = progressStream({
     length: _.parseInt(size),
     time: 500

--- a/lib/write.coffee
+++ b/lib/write.coffee
@@ -87,6 +87,9 @@ exports.write = (device, stream) ->
 	# Support resin-request streams length automatically
 	size = stream.length or stream.responseContent?.headers?['content-length']
 
+	if not size?
+		throw new Error('Stream size missing')
+
 	progress = progressStream
 		length: _.parseInt(size)
 		time: 500

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mocha": "~2.0.1",
     "mochainon": "^1.0.0",
     "nock": "^2.6.0",
-    "resin-request": "^2.1.0",
+    "resin-request": "^2.2.5",
     "resin-settings-client": "^1.3.0",
     "string-to-stream": "^1.0.1",
     "tmp": "0.0.26"

--- a/tests/write.spec.coffee
+++ b/tests/write.spec.coffee
@@ -24,10 +24,23 @@ describe 'Image Write:', ->
 			after ->
 				@device.removeCallback()
 
+			describe 'given a valid stream without size information', ->
+
+				beforeEach ->
+					message = 'Lorem ipsum dolor sit amet'
+					@stream = stringToStream(message)
+
+				it 'should throw an error', ->
+					m.chai.expect =>
+						imageWrite.write(@device.name, @stream)
+					.to.throw('Stream size missing')
+
 			describe 'given a valid stream', ->
 
 				beforeEach ->
-					@stream = stringToStream('Lorem ipsum dolor sit amet')
+					message = 'Lorem ipsum dolor sit amet'
+					@stream = stringToStream(message)
+					@stream.length = Buffer.byteLength(message)
 
 				it 'should be able to write the stream to a device', (done) ->
 


### PR DESCRIPTION
Currently, this module attempts to get size information from a `length`
property, or a `content-length` HTTP header if coming from Resin
Request.

The CLI attempts to always display a progress bar when writing an image,
therefore the absence of this property represents a UX error (a spinner
is not enough in this case, since the whole purpose of building this
module is to be able to provide progress of the operation).