### PR TITLE
Use OS X raw devices automatically

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -58,3 +58,29 @@ exports.eraseMBR = function(device) {
     });
   });
 };
+
+
+/**
+ * @summary Get raw device file
+ * @function
+ * @protected
+ *
+ * @description
+ * This function only performs manipulations for OS X disks.
+ * See http://superuser.com/questions/631592/why-is-dev-rdisk-about-20-times-faster-than-dev-disk-in-mac-os-x
+ *
+ * @param {String} device - device
+ * @returns {String} raw device
+ *
+ * @example
+ * rawDevice = utils.getRawDevice('/dev/disk2')
+ */
+
+exports.getRawDevice = function(device) {
+  var match;
+  match = device.match(/\/dev\/disk(\d+)/);
+  if (match == null) {
+    return device;
+  }
+  return "/dev/rdisk" + match[1];
+};

--- a/build/write.js
+++ b/build/write.js
@@ -100,6 +100,7 @@ exports.write = function(device, stream) {
   if (stream.length == null) {
     throw new Error('Stream size missing');
   }
+  device = utils.getRawDevice(device);
   progress = progressStream({
     length: _.parseInt(stream.length),
     time: 500

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -49,3 +49,23 @@ exports.eraseMBR = (device) ->
 			if bytesWritten isnt bufferSize
 				throw new Error("Bytes written: #{bytesWritten}, expected #{bufferSize}")
 			fs.closeAsync(fd)
+
+###*
+# @summary Get raw device file
+# @function
+# @protected
+#
+# @description
+# This function only performs manipulations for OS X disks.
+# See http://superuser.com/questions/631592/why-is-dev-rdisk-about-20-times-faster-than-dev-disk-in-mac-os-x
+#
+# @param {String} device - device
+# @returns {String} raw device
+#
+# @example
+# rawDevice = utils.getRawDevice('/dev/disk2')
+###
+exports.getRawDevice = (device) ->
+	match = device.match(/\/dev\/disk(\d+)/)
+	return device if not match?
+	return "/dev/rdisk#{match[1]}"

--- a/lib/write.coffee
+++ b/lib/write.coffee
@@ -89,6 +89,8 @@ exports.write = (device, stream) ->
 	if not stream.length?
 		throw new Error('Stream size missing')
 
+	device = utils.getRawDevice(device)
+
 	progress = progressStream
 		length: _.parseInt(stream.length)
 		time: 500

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -1,0 +1,15 @@
+m = require('mochainon')
+utils = require('../lib/utils')
+
+describe 'Utils:', ->
+
+	describe '.getRawDevice()', ->
+
+		it 'should return the raw device given an OS X disk', ->
+			m.chai.expect(utils.getRawDevice('/dev/disk2')).to.equal('/dev/rdisk2')
+
+		it 'should return the same device given a linux drive', ->
+			m.chai.expect(utils.getRawDevice('/dev/sda1')).to.equal('/dev/sda1')
+
+		it 'should return the same device given a Windows physical drive', ->
+			m.chai.expect(utils.getRawDevice('\\\\.\\PHYSICALDRIVE1')).to.equal('\\\\.\\PHYSICALDRIVE1')


### PR DESCRIPTION
For a device `/dev/diskN`, there exists a raw device `/dev/rdiskN`.

A raw device is almost 4 times faster than the other.